### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
+*       @celo-org/devtooling


### PR DESCRIPTION
Add a CODEOWNERS file.
Required step to be able to enfore CODEOWNERS review on the default branches.