### PR TITLE
Add Biochar (CHAR) from Toucan

### DIFF
--- a/celo.tokenlist.json
+++ b/celo.tokenlist.json
@@ -2,8 +2,8 @@
   "name": "Celo Token List",
   "version": {
     "major": 2,
-    "minor": 4,
-    "patch": 1
+    "minor": 5,
+    "patch": 0
   },
   "logoURI": "https://celo-org.github.io/celo-token-list/assets/celo_logo.svg",
   "keywords": ["celo", "tokens", "refi"],

--- a/celo.tokenlist.json
+++ b/celo.tokenlist.json
@@ -50,6 +50,14 @@
       "logoURI": "https://toucan.earth/img/icons/nct.svg"
     },
     {
+      "name": "Biochar",
+      "address": "0x50E85c754929840B58614F48e29C64BC78C58345",
+      "symbol": "CHAR",
+      "decimals": 18,
+      "chainId": 42220,
+      "logoURI": "https://app.toucan.earth/svg/pools/char.svg"
+    },
+    {
       "name": "USDC (Portal from Ethereum)",
       "address": "0x37f750B7cC259A2f741AF45294f6a16572CF5cAd",
       "symbol": "USDCet",


### PR DESCRIPTION
The CHAR token has enabled the first liquid market for biochar credits, which is a Uniswap pool deployed on Celo:

https://info.uniswap.org/#/celo/pools/0x7f7c4335ccac291ddedcef4429a626c442b627ed

More information is available here:

https://toucan.earth/toucan-earth-introducing-char-biochar-credits/