### PR TITLE
MGP12 Mento Stablecoin Rebrand

### DIFF
--- a/celo.testnet.tokenlist.json
+++ b/celo.testnet.tokenlist.json
@@ -3,7 +3,7 @@
     "version": {
       "major": 2,
       "minor": 5,
-      "patch": 0
+      "patch": 1
     },
     "logoURI": "https://celo-org.github.io/celo-token-list/assets/celo_logo.svg",
     "keywords": ["celo", "tokens", "refi"],

--- a/celo.testnet.tokenlist.json
+++ b/celo.testnet.tokenlist.json
@@ -26,12 +26,12 @@
         "logoURI": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mcEUR.png"
       },
       {
-        "name": "Celo Euro",
+        "name": "Mento Euro",
         "address": "0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F",
-        "symbol": "cEUR",
+        "symbol": "EURm",
         "decimals": 18,
         "chainId": 44787,
-        "logoURI": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cEUR.png"
+        "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/EURm.svg"
       },
       {
         "name": "NetM Token",
@@ -82,12 +82,12 @@
         "logoURI": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_mCELO.png"
       },
       {
-        "name": "Celo Dollar",
+        "name": "Mento Dollar",
         "address": "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
-        "symbol": "cUSD",
+        "symbol": "USDm",
         "decimals": 18,
         "chainId": 44787,
-        "logoURI": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cUSD.png"
+        "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/USDm.svg"
       },
       {
         "name": "Celo",

--- a/celo.tokenlist.json
+++ b/celo.tokenlist.json
@@ -119,7 +119,7 @@
       "symbol": "USDm",
       "decimals": 18,
       "chainId": 42220,
-      "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/cUSD.svg"
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/USDm.svg"
     },
     {
       "name": "Duniapay West African CFA franc",
@@ -143,7 +143,7 @@
       "symbol": "EURm",
       "decimals": 18,
       "chainId": 42220,
-      "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/cEUR.svg"
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/EURm.svg"
     },
     {
       "name": "Beefy Finance",
@@ -415,7 +415,7 @@
       "symbol": "BRLm",
       "decimals": 18,
       "chainId": 42220,
-      "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/cREAL.svg"
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/BRLm.svg"
     },
     {
       "name": "Poof USD",
@@ -591,7 +591,7 @@
       "symbol": "KESm",
       "decimals": 18,
       "chainId": 42220,
-      "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/cKES.svg"
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/KESm.svg"
     },
     {
       "name": "Wrapped BTC (Celo native bridge)",
@@ -615,7 +615,7 @@
       "symbol": "COPm",
       "decimals": 18,
       "chainId": 42220,
-      "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/cCOP.svg"
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/COPm.svg"
     },
     {
       "name": "Mento Ghanaian Cedi",
@@ -623,7 +623,7 @@
       "symbol": "GHSm",
       "decimals": 18,
       "chainId": 42220,
-      "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/cGHS.svg"
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/GHSm.svg"
     },
     {
       "name": "Mento West African CFA franc",
@@ -631,7 +631,7 @@
       "symbol": "XOFm",
       "decimals": 18,
       "chainId": 42220,
-      "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/eXOF.svg"
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/XOFm.svg"
     },
     {
       "name": "COP Minteo",

--- a/celo.tokenlist.json
+++ b/celo.tokenlist.json
@@ -2,8 +2,8 @@
   "name": "Celo Token List",
   "version": {
     "major": 3,
-    "minor": 6,
-    "patch": 1
+    "minor": 7,
+    "patch": 0
   },
   "logoURI": "https://celo-org.github.io/celo-token-list/assets/celo_logo.svg",
   "keywords": ["celo", "tokens", "refi"],

--- a/celo.tokenlist.json
+++ b/celo.tokenlist.json
@@ -602,12 +602,12 @@
       "logoURI": "https://celoscan.io/token/images/wbtccelo_32.svg"
     },
     {
-      "name": "PUSO",
+      "name": "Mento Philippine Peso",
       "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
-      "symbol": "PUSO",
+      "symbol": "PHPm",
       "decimals": 18,
       "chainId": 42220,
-      "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/PUSO.svg"
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/PHPm.svg"
     },
     {
       "name": "Mento Colombian Peso",
@@ -632,6 +632,62 @@
       "decimals": 18,
       "chainId": 42220,
       "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/XOFm.svg"
+    },
+    {
+      "name": "Mento British Pound",
+      "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+      "symbol": "GBPm",
+      "decimals": 18,
+      "chainId": 42220,
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/GBPm.svg"
+    },
+    {
+      "name": "Mento South African Rand",
+      "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+      "symbol": "ZARm",
+      "decimals": 18,
+      "chainId": 42220,
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/ZARm.svg"
+    },
+    {
+      "name": "Mento Canadian Dollar",
+      "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+      "symbol": "CADm",
+      "decimals": 18,
+      "chainId": 42220,
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/CADm.svg"
+    },
+    {
+      "name": "Mento Australian Dollar",
+      "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+      "symbol": "AUDm",
+      "decimals": 18,
+      "chainId": 42220,
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/AUDm.svg"
+    },
+    {
+      "name": "Mento Swiss Franc",
+      "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+      "symbol": "CHFm",
+      "decimals": 18,
+      "chainId": 42220,
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/CHFm.svg"
+    },
+    {
+      "name": "Mento Japanese Yen",
+      "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+      "symbol": "JPYm",
+      "decimals": 18,
+      "chainId": 42220,
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/JPYm.svg"
+    },
+    {
+      "name": "Mento Nigerian Naira",
+      "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+      "symbol": "NGNm",
+      "decimals": 18,
+      "chainId": 42220,
+      "logoURI": "https://raw.githubusercontent.com/mento-protocol/frontend-monorepo/refs/heads/main/apps/app.mento.org/public/tokens/NGNm.svg"
     },
     {
       "name": "COP Minteo",

--- a/celo.tokenlist.json
+++ b/celo.tokenlist.json
@@ -114,9 +114,9 @@
       "logoURI": "https://celo-org.github.io/celo-token-list/assets/celo_logo.svg"
     },
     {
-      "name": "Celo Dollar",
+      "name": "Mento Dollar",
       "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
-      "symbol": "cUSD",
+      "symbol": "USDm",
       "decimals": 18,
       "chainId": 42220,
       "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/cUSD.svg"
@@ -138,9 +138,9 @@
       "logoURI": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cBTC.png"
     },
     {
-      "name": "Celo Euro",
+      "name": "Mento Euro",
       "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
-      "symbol": "cEUR",
+      "symbol": "EURm",
       "decimals": 18,
       "chainId": 42220,
       "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/cEUR.svg"
@@ -410,9 +410,9 @@
       "logoURI": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_IMMO.png"
     },
     {
-      "name": "Celo Real",
+      "name": "Mento Brazilian Real",
       "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
-      "symbol": "cREAL",
+      "symbol": "BRLm",
       "decimals": 18,
       "chainId": 42220,
       "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/cREAL.svg"
@@ -586,9 +586,9 @@
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
     },
     {
-      "name": "Celo Kenyan Shilling",
+      "name": "Mento Kenyan Shilling",
       "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
-      "symbol": "cKES",
+      "symbol": "KESm",
       "decimals": 18,
       "chainId": 42220,
       "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/cKES.svg"
@@ -610,25 +610,25 @@
       "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/PUSO.svg"
     },
     {
-      "name": "Celo Colombian Peso",
+      "name": "Mento Colombian Peso",
       "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
-      "symbol": "cCOP",
+      "symbol": "COPm",
       "decimals": 18,
       "chainId": 42220,
       "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/cCOP.svg"
     },
     {
-      "name": "Celo Ghanaian Cedi",
+      "name": "Mento Ghanaian Cedi",
       "address": "0xfaea5f3404bba20d3cc2f8c4b0a888f55a3c7313",
-      "symbol": "cGHS",
+      "symbol": "GHSm",
       "decimals": 18,
       "chainId": 42220,
       "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/cGHS.svg"
     },
     {
-      "name": "ECO CFA (West African Franc)",
+      "name": "Mento West African CFA franc",
       "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
-      "symbol": "eXOF",
+      "symbol": "XOFm",
       "decimals": 18,
       "chainId": 42220,
       "logoURI": "https://raw.githubusercontent.com/mento-protocol/mento-web/refs/heads/main/public/tokens/eXOF.svg"


### PR DESCRIPTION
Updates to the name, symbol and logo URIs for existing Mento stables in line with [MGP12](https://governance.mento.org/proposals/47458687107201224660463917192129839152944041661489623687785188705766875598182).
